### PR TITLE
A bit of error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-image = "0.24.1"
+image = "0.24.5"
 walkdir = "2"
 pbr = "1.0.4"
 

--- a/src/image_transforms.rs
+++ b/src/image_transforms.rs
@@ -3,13 +3,13 @@ use image::io::Reader as ImageReader;
 use image::{DynamicImage, GenericImageView, ImageFormat};
 use std::{fs, os::unix::fs::MetadataExt};
 
-pub fn check_encoded_size(image_path: &str) -> Result<u64, Box<dyn std::error::Error>> {
+pub fn check_encoded_size(image_path: &str) -> std::io::Result<u64> {
     let meta = fs::metadata(image_path)?;
     let filesize = meta.size();
     return Ok(filesize);
 }
 
-pub fn process_image(image_path: &str, image_size: u64) -> Result<(), Box<dyn std::error::Error>> {
+pub fn process_image(image_path: &str, image_size: u64) -> image::ImageResult<()> {
     let image = read_image(image_path)?;
     let ratio = compute_ratio_fast(image_size);
 
@@ -21,7 +21,7 @@ pub fn process_image(image_path: &str, image_size: u64) -> Result<(), Box<dyn st
     Ok(())
 }
 
-pub fn read_image(image_path: &str) -> Result<DynamicImage, Box<dyn std::error::Error>> {
+pub fn read_image(image_path: &str) -> image::ImageResult<DynamicImage> {
     let image = ImageReader::open(image_path)?.decode()?;
     return Ok(image);
 }
@@ -44,8 +44,8 @@ fn compute_ratio_slow(image: DynamicImage) -> f32 {
         let tmp_image = image.resize(new_width, new_height, Triangle);
         //let mut buff = Vec::new();
         //tmp_image
-            //.write_to(&mut buff, image::ImageFormat::Jpeg)
-            //.unwrap();
+        //.write_to(&mut buff, image::ImageFormat::Jpeg)
+        //.unwrap();
         //max_image_size = buff.len();
         //println!("Ratio {}, image_size {} bytes", ratio, max_image_size);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use walkdir::WalkDir;
 use pbr::ProgressBar;
 use std::env;
+use walkdir::WalkDir;
 
 mod image_transforms;
 use image_transforms::{check_encoded_size, process_image};
@@ -14,8 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let walker = WalkDir::new(images_path);
     let mut progress_bar = ProgressBar::new(filecount);
 
-    for entry in walker.into_iter().filter_map(|e| e.ok()) {
-
+    for entry in walker.into_iter().flatten() {
         if entry.metadata()?.is_file() {
             if let Some(filename) = entry.path().to_str() {
                 let filesize = check_encoded_size(filename)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use pbr::ProgressBar;
 use std::env;
+use std::process::exit;
 use walkdir::WalkDir;
 
 mod image_transforms;
@@ -7,6 +8,12 @@ use image_transforms::{check_encoded_size, process_image};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Provide the source path as the argument to the program:");
+        eprintln!("{} <PATH>", args[0]);
+        exit(1);
+    }
+
     let images_path = &args[1];
 
     let walker = WalkDir::new(images_path);
@@ -18,9 +25,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if entry.metadata()?.is_file() {
             if let Some(filename) = entry.path().to_str() {
                 let filesize = check_encoded_size(filename)?;
+                if 1000000 <= filesize {
+                    continue;
+                }
 
-                if filesize >= 1000000 {
-                    process_image(filename, filesize)?;
+                if let Err(e) = process_image(filename, filesize) {
+                    eprintln!("Skipping file {filename}: {e}")
                 }
             }
         }


### PR DESCRIPTION
This PR adds a bit of error handling to the code. It adds a basic argument validation and prints an error message for unprocessable files.

I also replaced `filter_map(|e| e.ok()) ` with `flatten()` which should do the same.