### PR TITLE
Png white background

### DIFF
--- a/src/image_transforms.rs
+++ b/src/image_transforms.rs
@@ -3,8 +3,6 @@ use image::io::Reader as ImageReader;
 use image::{DynamicImage, GenericImageView, ImageFormat};
 use std::{fs, io::BufReader, os::unix::fs::MetadataExt};
 
-use exif;
-
 pub fn read_exif_metadata(image_path: &str) -> Option<u32> {
     let file = fs::File::open(image_path).unwrap();
 
@@ -27,7 +25,7 @@ pub fn read_exif_metadata(image_path: &str) -> Option<u32> {
 pub fn check_encoded_size(image_path: &str) -> std::io::Result<u64> {
     let meta = fs::metadata(image_path)?;
     let filesize = meta.size();
-    return Ok(filesize);
+    Ok(filesize)
 }
 
 pub fn process_image(image_path: &str, image_size: u64) -> image::ImageResult<()> {
@@ -57,9 +55,9 @@ pub fn process_image(image_path: &str, image_size: u64) -> image::ImageResult<()
 
 pub fn read_image(image_path: &str) -> image::ImageResult<DynamicImage> {
     let image = ImageReader::open(image_path)?.decode()?;
-    return Ok(image);
+    Ok(image)
 }
 
 pub fn compute_ratio_fast(image_size: u64) -> f64 {
-    return image_size as f64 / 1000000.0;
+    image_size as f64 / 1000000.0
 }

--- a/src/image_transforms.rs
+++ b/src/image_transforms.rs
@@ -66,5 +66,6 @@ pub fn read_image(image_path: &str) -> image::ImageResult<DynamicImage> {
 }
 
 pub fn compute_ratio_fast(image_size: u64) -> f64 {
-    image_size as f64 / 1000000.0
+    let ratio = image_size as f64 / 1000000.0;
+    ratio.sqrt()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,4 +48,3 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     progress_bar.finish();
     Ok(())
 }
-


### PR DESCRIPTION
This MR will fix clippy warnings, fix the background from black to white for PNG images that are converted to JPEG and fix the ratio being too big